### PR TITLE
Deprecate `addFeatherIcon` and `addAllFeatherIcos` because Obsidian now ships a full Icon Library

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,8 @@ export async function wait(delay: number): Promise<void> {
  * https://feathericons.com/
  *
  * @param attr SVG Attributes for the Icon. The default should work for most usecases.
+ * 
+ * @deprecated As of Obsidian 0.13.27 this is no longer needed, because Obsidian ships with `lucide`, a maintained fork of feather. (https://lucide.dev/)
  */
 export function addAllFeatherIcons(
   attr = { viewBox: "0 0 24 24", width: "100", height: "100" }
@@ -52,6 +54,8 @@ export function addAllFeatherIcons(
  * @param name official Name of the Icon (https://feathericons.com/)
  * @param attr SVG Attributes for the Icon. The default should work for most usecases.
  * @returns {string} Icon name
+ * 
+ * @deprecated As of Obsidian 0.13.27 this is no longer needed, because Obsidian ships with `lucide`, a maintained fork of feather. (https://lucide.dev/)
  */
 export function addFeatherIcon(
   name: string,


### PR DESCRIPTION
Deprecate `addFeatherIcon` and `addAllFeatherIcos` because Obsidian now ships a full Icon Library

- [x] I agree to the contribution guidelines laid out [here](https://github.com/obsidian-community/obsidian-community-lib#contributing) in the readme.
