### PR TITLE
chore: upgrade deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,17 +46,20 @@
     },
     "homepage": "https://github.com/obsidian-community/obsidian-community-lib#readme",
     "devDependencies": {
-        "@types/feather-icons": "^4.7.0",
-        "@types/jest": "^27.4.1",
-        "jest": "^27.5.1",
+        "@types/events": "^3.0.0",
+        "@types/feather-icons": "^4.29.1",
+        "@types/jest": "^29.5.4",
+        "events": "^3.3.0",
+        "jest": "^29.6.4",
+        "jest-environment-jsdom": "^29.6.4",
         "standard-version": "^9.3.2",
-        "ts-jest": "^27.1.4",
+        "ts-jest": "^29.1.1",
         "ts-node": "^10.7.0",
-        "typedoc": "^0.22.6",
-        "typescript": "^4.6.3"
+        "typedoc": "^0.25.0",
+        "typescript": "^5.2.2"
     },
     "dependencies": {
         "feather-icons": "^4.28.0",
-        "obsidian": "^0.15.4"
+        "obsidian": "^1.4.4"
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -261,8 +261,8 @@ export async function openOrSwitch(
     const mode = app.vault.getConfig("defaultViewMode") as string;
     const leaf =
       event.ctrlKey || event.getModifierState("Meta")
-        ? workspace.splitActiveLeaf()
-        : workspace.getUnpinnedLeaf();
+        ? workspace.getLeaf(true)
+        : workspace.getLeaf(false);
 
     //@ts-expect-error
     await leaf.openFile(destFile, { active: true, mode });
@@ -395,7 +395,7 @@ export class RenderedMarkdownModal<YourPlugin extends Plugin> extends Modal {
       contentEl.empty();
     }
     const logDiv = contentEl.createDiv({ cls: "OCL-RenderedMarkdownModal" });
-    MarkdownRenderer.renderMarkdown(content, logDiv, "", plugin);
+    MarkdownRenderer.render(app, content, logDiv, "", plugin);
   }
 
   onClose() {


### PR DESCRIPTION
- [x] I agree to the contribution guidelines laid out [here](https://github.com/obsidian-community/obsidian-community-lib#contributing) in the readme.

My IDE always showed two versions of obsidian, which was strange. I identified that this packages is still using obsidian <1.0.0. So I updated all dependencies and migrated some deprecation warnings. The global `app` is deprecated as well. I would keep it for, as it would be a huge breaking change.

EDIT:
I haven't much tested this, because I'm only using `hoverPreview` in that plugin, but I don't think anything could actually go wrong, because I mostly updated type defs.